### PR TITLE
ELPP-3360 Start any workflow

### DIFF
--- a/econtools/aws.py
+++ b/econtools/aws.py
@@ -1,0 +1,11 @@
+import boto.sqs
+import boto.sqs.connection
+import os
+
+def get_queue(queue_name):
+    sqs_conn = boto.sqs.connect_to_region(os.environ['AWS_DEFAULT_REGION'])
+    queue = sqs_conn.get_queue(queue_name)
+    if queue is None:
+        print("Could not obtain workflow starter queue %s\n" % queue_name)
+        exit()
+    return queue

--- a/econtools/econ_article_feeder.py
+++ b/econtools/econ_article_feeder.py
@@ -13,6 +13,7 @@ import re
 import json
 import os
 import sys
+from econtools.aws import get_queue
 
 
 def feed_econ(bucket_name, queue_name, rate=30, prefix=None, key_filter=None, working=False, workflow_name="IngestArticleZip"):
@@ -101,7 +102,7 @@ def get_options():
                       help="show progress indicator to indicate working")
 
     opts, ags = parser.parse_args()
-    if (len(ags) < 2) and (len(ags) > 3):
+    if (len(ags) < 2) or (len(ags) > 3):
         parser.error("incorrect number of arguments")
 
     return opts, ags

--- a/econtools/econ_article_feeder.py
+++ b/econtools/econ_article_feeder.py
@@ -102,7 +102,7 @@ def get_options():
                       help="show progress indicator to indicate working")
 
     opts, ags = parser.parse_args()
-    if (len(ags) < 2) or (len(ags) > 3):
+    if len(ags) not in [2, 3]:
         parser.error("incorrect number of arguments")
 
     return opts, ags

--- a/econtools/econ_workflow.py
+++ b/econtools/econ_workflow.py
@@ -10,12 +10,12 @@ import boto.sqs.connection
 from econtools.aws import get_queue
 
 
-def start_workflow(queue_name, workflow_name):
+def start_workflow(queue_name, workflow_name, workflow_data={}):
 
     queue = get_queue(queue_name)
     message = {
         'workflow_name': workflow_name,
-        'workflow_data': {}
+        'workflow_data': workflow_data,
     }
 
     msg = boto.sqs.connection.Message()
@@ -27,13 +27,14 @@ def get_args():
     parser = ArgumentParser(description="Starts any workflow")
     parser.add_argument('queue_name', type=str, help='The queue to add the starting message to')
     parser.add_argument('workflow_name', type=str, help='The workflow type to start')
+    parser.add_argument('workflow_data', type=str, help='The workflow data in JSON format e.g. \`{"a": 42}\`', nargs='?', default='{}')
 
     return parser.parse_args()
 
 
 def main():
     args = get_args()
-    start_workflow(args.queue_name, args.workflow_name)
+    start_workflow(args.queue_name, args.workflow_name, json.loads(args.workflow_data))
 
 
 if __name__ == "__main__":

--- a/econtools/econ_workflow.py
+++ b/econtools/econ_workflow.py
@@ -1,0 +1,41 @@
+
+"""
+econ_workflow.py - starts arbitrary continuum publishing workflows
+"""
+
+from optparse import OptionParser
+import json
+import boto.sqs
+import boto.sqs.connection
+from econtools.aws import get_queue
+
+
+def start_workflow(queue_name, workflow_name):
+
+    queue = get_queue(queue_name)
+    message = {
+        'workflow_name': workflow_name,
+        'workflow_data': {}
+    }
+
+    msg = boto.sqs.connection.Message()
+    msg.set_body(json.dumps(message))
+    queue.write(msg)
+
+def get_args():
+    usage = "usage: %prog workflow_starter_queue IngestArticleZip"
+    parser = OptionParser(usage=usage)
+
+    _, args = parser.parse_args()
+    if (len(args) < 2) or (len(args) > 3):
+        parser.error("incorrect number of arguments")
+
+    return args
+
+def main():
+    args = get_args()
+    start_workflow(args[0], args[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/econtools/econ_workflow.py
+++ b/econtools/econ_workflow.py
@@ -3,7 +3,7 @@
 econ_workflow.py - starts arbitrary continuum publishing workflows
 """
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 import json
 import boto.sqs
 import boto.sqs.connection
@@ -24,17 +24,16 @@ def start_workflow(queue_name, workflow_name):
 
 def get_args():
     usage = "usage: %prog workflow_starter_queue IngestArticleZip"
-    parser = OptionParser(usage=usage)
+    parser = ArgumentParser(description="Starts any workflow")
+    parser.add_argument('queue_name', type=str, help='The queue to add the starting message to')
+    parser.add_argument('workflow_name', type=str, help='The workflow type to start')
 
-    _, args = parser.parse_args()
-    if len(args) != 2:
-        parser.error("incorrect number of arguments")
+    return parser.parse_args()
 
-    return args
 
 def main():
     args = get_args()
-    start_workflow(args[0], args[1])
+    start_workflow(args.queue_name, args.workflow_name)
 
 
 if __name__ == "__main__":

--- a/econtools/econ_workflow.py
+++ b/econtools/econ_workflow.py
@@ -27,7 +27,7 @@ def get_args():
     parser = OptionParser(usage=usage)
 
     _, args = parser.parse_args()
-    if (len(args) < 2) or (len(args) > 3):
+    if len(args) != 2:
         parser.error("incorrect number of arguments")
 
     return args

--- a/econtools/test_workflow.py
+++ b/econtools/test_workflow.py
@@ -1,0 +1,23 @@
+import json
+import unittest
+from mock import MagicMock, patch
+from boto.sqs.message import Message
+from econtools import econ_workflow
+
+class TestWorkflow(unittest.TestCase):
+    @patch('econtools.econ_workflow.get_queue')
+    def test_feed_two_articles(self, get_queue):
+        queue = MagicMock()
+        get_queue.return_value = queue
+        econ_workflow.start_workflow('ct-workflow-starter-queue', workflow_name='MyArticleWorkflow')
+
+        self.assertEqual(len(queue.method_calls), 1)
+        (_, args, _) = queue.method_calls[0]
+        message_body = args[0].get_body()
+        self.assertEqual(
+            json.loads(message_body),
+            {
+                'workflow_name': 'MyArticleWorkflow',
+                'workflow_data': {},
+            }
+        )

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -6,6 +6,6 @@ virtualenv venv
 source venv/bin/activate
 pip install -r requirements.txt
 pylint -E *.py
-coverage run -m pytest econtools/test_feeder.py
+coverage run -m pytest econtools/test_*.py
 coverage report -m econtools/*.py
 


### PR DESCRIPTION
Without involvement of S3 bucket. The workflow data is always empty, but it can be extended later to allow passing it in from the cli.

This could be down with `aws sqs`, but the attempt is to provide a uniform interface to the bot.

To be used to trigger a Pubmed deposit in https://github.com/elifesciences/elife-spectrum/pull/87