### PR TITLE
Switch IngestArticleZip to InitialArticleZip in readme and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Usage:
 ```
     econ_article_feeder.py [options] bucket_name workflow_starter_queue_name workflow_name
 
-    $ python econtools/econ_article_feeder.py -p elife-14721-vor-r1 -r 1  elife-production-final workflow-starter-queue IngestArticleZip
+    $ python econtools/econ_article_feeder.py -p elife-14721-vor-r1 -r 1  elife-production-final workflow-starter-queue InitialArticleZip
 ```
     
 Options:

--- a/econtools/econ_article_feeder.py
+++ b/econtools/econ_article_feeder.py
@@ -16,7 +16,7 @@ import sys
 from econtools.aws import get_queue
 
 
-def feed_econ(bucket_name, queue_name, rate=30, prefix=None, key_filter=None, working=False, workflow_name="IngestArticleZip"):
+def feed_econ(bucket_name, queue_name, rate=30, prefix=None, key_filter=None, working=False, workflow_name="InitialArticleZip"):
 
     message = "\nFeeding any keys in %s " % bucket_name
     if prefix is not None:
@@ -90,7 +90,7 @@ def now():
     return datetime.now()
 
 def get_options():
-    usage = "usage: %prog [options] bucket_name workflow_starter_queue IngestArticleZip"
+    usage = "usage: %prog [options] bucket_name workflow_starter_queue InitialArticleZip"
     parser = OptionParser(usage=usage)
     parser.add_option("-p", "--prefix", default=None, action="store", type="string", dest="prefix",
                       help="only feed keys with the given prefix")


### PR DESCRIPTION
…econ_article_feeder.py

This would hopefully help people not to make the same error I made this morning. Since the bot workflow that responds to S3 notifications is now named ``InitialArticleZip``, if you try feeding with the workflow name ``IngestArticleZip`` it causes an error.

The value of ``IngestArticleZip`` in the https://github.com/elifesciences/econ-tools/blob/master/econtools/econ_workflow.py file should be ok, because that is the next step, where ``workflow_data`` is supplied explicitly, and ``IngestArticleZip`` will work in that case, if the data supplied is correct.