### PR TITLE
deps, setup.py requirements now follow Pipfile,

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [requires]
 python_version = "3.8"
 
+# see also setup.py
 [packages]
 boto3 = "~=1.24"
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ from setuptools import setup
 with open('README.md') as fp:
     readme = fp.read()
 
-with open('requirements.txt') as f:
-    install_requires = f.read().splitlines()
+install_requires = [
+    "boto3<2.0.0",
+]
 
 setup(name='econtools',
     version=econtools.__version__,


### PR DESCRIPTION
rather than the frozen requirements.txt file. Those are less suitable for libraries as dependents will also require fixed versions.